### PR TITLE
Fix bug for firefox where object.watch is interpreted as a html attribute

### DIFF
--- a/scrollable.js
+++ b/scrollable.js
@@ -92,7 +92,7 @@
             // Call scroller after transclusion
             timerCancelStatic = $timeout(listener);
           }
-          else if (attr['watch'] || attr['watchCollection']) {
+          else if (typeof attr['watch'] === 'string' || attr['watchCollection']) {
             angular.forEach(splitter(attr['watch']), function (v) {
               scope.$watch(v, collectionListener);
             });


### PR DESCRIPTION
This causes the split function to fail because attr['watch'] is a function.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/watch
